### PR TITLE
Fix for Windows, both oF v0.12.1 / oF v0.12.0

### DIFF
--- a/src/ofxSvgElements.h
+++ b/src/ofxSvgElements.h
@@ -129,7 +129,7 @@ public:
 	virtual void draw() override;
 	glm::vec2 getAnchorPointForPercent( float ax, float ay );
 	
-	std::string getFilePath() { return filepath; }
+	std::string getFilePath() { return filepath.string(); }
 	
 	void setColor( ofColor aColor ) {
 		color = aColor;

--- a/src/ofxSvgParser.cpp
+++ b/src/ofxSvgParser.cpp
@@ -784,7 +784,7 @@ void Parser::_parsePath( ofXml& tnode, std::shared_ptr<Path> aSvgPath ) {
 		
 		bool bRelative = false;
 		std::vector<glm::vec3> npositions= {glm::vec3(0.f, 0.f, 0.f)};
-		std::optional<ofPath::Command::Type> ctype;
+		CssClass::Optional<ofPath::Command::Type> ctype;
 		
 		// check if we are looking for a position
 		if( cchar == 'm' || cchar == 'M' ) {

--- a/src/ofxSvgParser.cpp
+++ b/src/ofxSvgParser.cpp
@@ -8,6 +8,7 @@
 #include "ofUtils.h"
 #include <regex>
 #include "ofGraphics.h"
+#include "boost/optional.hpp"
 
 using namespace ofx::svg;
 using std::string;
@@ -27,7 +28,7 @@ bool Parser::load( of::filesystem::path aPathToSvg ) {
     ofFile mainXmlFile( aPathToSvg, ofFile::ReadOnly );
     ofBuffer tMainXmlBuffer( mainXmlFile );
     
-    svgPath     = aPathToSvg;
+    svgPath     = aPathToSvg.string();
     folderPath  = ofFilePath::getEnclosingDirectory( aPathToSvg, false );
     
     ofXml xml;
@@ -784,7 +785,7 @@ void Parser::_parsePath( ofXml& tnode, std::shared_ptr<Path> aSvgPath ) {
 		
 		bool bRelative = false;
 		std::vector<glm::vec3> npositions= {glm::vec3(0.f, 0.f, 0.f)};
-		std::optional<ofPath::Command::Type> ctype;
+		boost::optional<ofPath::Command::Type> ctype;
 		
 		// check if we are looking for a position
 		if( cchar == 'm' || cchar == 'M' ) {
@@ -860,7 +861,7 @@ void Parser::_parsePath( ofXml& tnode, std::shared_ptr<Path> aSvgPath ) {
 //			}
 		}
 		
-		if( ctype.has_value() ) {
+		if( ctype != boost::none ) {
 			
 //			for( auto& np : npositions ) {
 //				ofLogNotice(moduleName()) << cchar << " position: " << np;

--- a/src/ofxSvgParser.cpp
+++ b/src/ofxSvgParser.cpp
@@ -8,7 +8,6 @@
 #include "ofUtils.h"
 #include <regex>
 #include "ofGraphics.h"
-#include "boost/optional.hpp"
 
 using namespace ofx::svg;
 using std::string;
@@ -785,7 +784,7 @@ void Parser::_parsePath( ofXml& tnode, std::shared_ptr<Path> aSvgPath ) {
 		
 		bool bRelative = false;
 		std::vector<glm::vec3> npositions= {glm::vec3(0.f, 0.f, 0.f)};
-		boost::optional<ofPath::Command::Type> ctype;
+		std::optional<ofPath::Command::Type> ctype;
 		
 		// check if we are looking for a position
 		if( cchar == 'm' || cchar == 'M' ) {
@@ -861,7 +860,7 @@ void Parser::_parsePath( ofXml& tnode, std::shared_ptr<Path> aSvgPath ) {
 //			}
 		}
 		
-		if( ctype != boost::none ) {
+		if( ctype.has_value() ) {
 			
 //			for( auto& np : npositions ) {
 //				ofLogNotice(moduleName()) << cchar << " position: " << np;


### PR DESCRIPTION
Confirmed working both macOS / Windows oF v0.12.1

( I also confirmed that without `.string()` not works on Windows. )